### PR TITLE
Fix issues with README.md

### DIFF
--- a/day2/README.md
+++ b/day2/README.md
@@ -368,7 +368,14 @@ ros2 run ros_gz_bridge parameter_bridge \
 
 # TF
 ros2 run tf2_ros static_transform_publisher \
-  0 0 0.1 0 0 0 base_link laser_frame
+  --x 0   \
+  --y 0   \
+  --z 0.1 \
+  --qx 0  \
+  --qy 0  \
+  --qz 0  \
+  --frame-id base_link \
+  --child-frame-id laser_frame
 
 # RViz
 rviz2

--- a/day2/README.md
+++ b/day2/README.md
@@ -364,7 +364,7 @@ gz sim basic_urdf.sdf
 
 # Bridge
 ros2 run ros_gz_bridge parameter_bridge \
-  /scan@sensor_msgs/msg/LaserScan[gz.msgs.LaserScan
+  /scan@sensor_msgs/msg/LaserScan\[gz.msgs.LaserScan
 
 # TF
 ros2 run tf2_ros static_transform_publisher \


### PR DESCRIPTION
Bash seems to be fine with unescaped [ chars, but most shells will complain (zsh does at the very least), and this change still works for bash 

Also removed the following warning/updated:
```
[WARN] [1772694673.445689170] []: Old-style arguments are deprecated; see --help for new-style arguments
``` 
from `static_transform_publisher`

Reason for commit:
Spent too long finding the issue. At some point I may put some more PR's in for other things I found during the workshop - these are just the ones I found setting up the project